### PR TITLE
Fix WiiU Port

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .DEFAULT_GOAL := all
 
 NAME		=  s122013
-SUFFIX		= 
+SUFFIX		=
 PKGCONFIG	=  pkg-config
 DEBUG		?= 0
 STATIC		?= 1
@@ -130,7 +130,7 @@ $(OBJDIR)/%.o: %.cpp
 
 $(BINPATH): $(OBJDIR) $(OBJECTS)
 	@echo -n Linking...
-	$(CXX) $(CFLAGS) $(LDFLAGS) $(OBJECTS) -o $@ $(LIBS)
+	$(CXX) $(CFLAGS) $(LDFLAGS) $(OBJECTS) -o $@ $(LIBS) $(SYSLIBS)
 	@echo " Done!"
 	$(STRIP) $@
 

--- a/Makefile_cfgs/Platforms/WiiU.cfg
+++ b/Makefile_cfgs/Platforms/WiiU.cfg
@@ -7,40 +7,33 @@ BACKEND_VIDEO ?= sdl2
 BACKEND_INPUT ?= sdl2
 BACKEND_AUDIO ?= null
 
-
-ifeq ($(strip $(DEVKITPPC)),)
-$(error "Please set DEVKITPPC in your environment. export DEVKITPPC=<path to>devkitPPC")
-endif
 ifeq ($(strip $(DEVKITPRO)),)
-$(error "Please set DEVKITPRO in your environment. export DEVKITPRO=<path to>devkitPRO")
+$(error "Please set DEVKITPRO in your environment. export DEVKITPRO=<path to>/devkitPro")
 endif
-export PATH			:=	$(DEVKITPPC)/bin:$(PORTLIBS)/bin:$(PATH)
-export LIBOGC_INC	:=	$(DEVKITPRO)/libogc/include
-export LIBOGC_LIB	:=	$(DEVKITPRO)/libogc/lib/wii
-export PORTLIBS		:=	$(DEVKITPRO)/portlibs/ppc
-
-PREFIX	:=	powerpc-eabi-
-
-export AS	:=	$(PREFIX)as
-export CC	:=	$(PREFIX)gcc
-export CXX	:=	$(PREFIX)g++
-export AR	:=	$(PREFIX)ar
-export OBJCOPY	:=	$(PREFIX)objcopy
-
-
 
 PKGCONFIG =	$(DEVKITPRO)/portlibs/wiiu/bin/powerpc-eabi-pkg-config
 
+include $(DEVKITPRO)/wut/share/wut_rules
+#some slight hacks to patch the devkitPro rules into this one
 
-CFLAGS +=	-std=gnu11 -mrvl -mcpu=750 -meabi -mhard-float -ffast-math \
-		    -O3  -Wall -Wextra -Wno-unused-parameter -Wno-strict-aliasing
-# DEFINES +=	-DHAVE_ALLOCA_H
-LIBS +=		-L$(DEVKITPPC)/lib -L$(DEVKITPPC)/lib/gcc/powerpc-eabi/4.8.2
-INCLUDES +=	-I$(LIBOGC_INC) -I$(DEVKITPRO)/portlibs/wiiu/include/SDL2 -I$(PORTLIBS)/include -I$(DEVKITPRO)/portlibs/wiiu/include -I$(DEVKITPPC)/lib/gcc/powerpc-eabi/4.8.2
+#stripping wiiu binaries fully isn't really a thing yet
+STRIP := $(STRIP) -g
+
+#link wut
+CFLAGS += -isystem $(WUT_ROOT)/include $(MACHDEP)
+LDFLAGS += -L$(WUT_ROOT)/lib
+SYSLIBS += -lwut
+
+LDFLAGS += $(RPXSPECS)
+
+#extra application bits
+CFLAGS += -ffast-math -ffunction-sections
+DEFINES +=	-DHAVE_ALLOCA_H -D__WIIU__
+
+#just for fun - the toolchain supports it
+ifeq ($(LTO),1)
+	CFLAGS += -flto
+endif
 
 SUFFIX =	.elf
-
-# $(PKGPATH): $(OUTDIR)/$(NAME)
-# 	@echo -n "Building nro..."
-# 	@elf2nro $< $@ $(NROFLAGS)
-# 	@echo " Done!"
+PKGSUFFIX =	.rpx

--- a/Sonic12Decomp/Animation.cpp
+++ b/Sonic12Decomp/Animation.cpp
@@ -17,12 +17,12 @@ void LoadAnimationFile(char *filePath)
 {
     FileInfo info;
     if (LoadFile(filePath, &info)) {
-        int fileBuffer = 0;
+        byte fileBuffer = 0;
         char strBuf[0x21];
         byte sheetIDs[0x18];
         sheetIDs[0] = 0;
 
-        int sheetCount = 0;
+        byte sheetCount = 0;
         FileRead(&sheetCount, 1); // Sheet Count
 
         for (int s = 0; s < sheetCount; ++s) {
@@ -38,7 +38,7 @@ void LoadAnimationFile(char *filePath)
             }
         }
 
-        int animCount = 0;
+        byte animCount = 0;
         FileRead(&animCount, 1);
         AnimationFile *animFile = &animationFileList[animationFileCount];
         animFile->animCount     = animCount;
@@ -60,10 +60,15 @@ void LoadAnimationFile(char *filePath)
                 FileRead(&frame->sheetID, 1);
                 frame->sheetID = sheetIDs[frame->sheetID];
                 FileRead(&frame->hitboxID, 1);
-                FileRead(&frame->sprX, 1);
-                FileRead(&frame->sprY, 1);
-                FileRead(&frame->width, 1);
-                FileRead(&frame->height, 1);
+                byte x, y, w, h;
+                FileRead(&x, 1);
+                frame->sprX = x;
+                FileRead(&y, 1);
+                frame->sprY = y;
+                FileRead(&w, 1);
+                frame->width = w;
+                FileRead(&h, 1);
+                frame->height = h;
 
                 sbyte buffer = 0;
                 FileRead(&buffer, 1);

--- a/Sonic12Decomp/Audio.cpp
+++ b/Sonic12Decomp/Audio.cpp
@@ -68,7 +68,7 @@ int InitAudioPlayback()
     FileInfo info;
     FileInfo infoStore;
     char strBuffer[0x100];
-    int fileBuffer  = 0;
+    byte fileBuffer  = 0;
     int fileBuffer2 = 0;
 
     if (LoadFile("Data/Game/Gameconfig.bin", &info)) {
@@ -84,7 +84,7 @@ int InitAudioPlayback()
         for (int c = 0; c < 0x60; ++c) FileRead(buf, 3);
 
         // Read Obect Names
-        int objectCount = 0;
+        byte objectCount = 0;
         FileRead(&objectCount, 1);
         for (int o = 0; o < objectCount; ++o) {
             FileRead(&fileBuffer, 1);
@@ -97,7 +97,7 @@ int InitAudioPlayback()
             FileRead(&strBuffer, fileBuffer);
         }
 
-        int varCount = 0;
+        byte varCount = 0;
         FileRead(&varCount, 1);
         globalVariablesCount = varCount;
         for (int v = 0; v < varCount; ++v) {
@@ -112,7 +112,9 @@ int InitAudioPlayback()
 
         // Read SFX
         globalSFXCount = 0;
-        FileRead(&globalSFXCount, 1);
+        byte sfxCount;
+        FileRead(&sfxCount, 1);
+        globalSFXCount = sfxCount;
         for (int s = 0; s < globalSFXCount; ++s) { // SFX Names
             FileRead(&fileBuffer, 1);
             FileRead(&strBuffer, fileBuffer);
@@ -397,10 +399,10 @@ bool PlayMusic(int track, int musStartPos)
         StopMusic();
         return false;
     }
-    
+
     if (musInfo.loaded)
         StopMusic();
-    
+
     LOCK_AUDIO_DEVICE()
     uint oldPos   = 0;
     uint oldTotal = 0;

--- a/Sonic12Decomp/Endian.hpp
+++ b/Sonic12Decomp/Endian.hpp
@@ -1,0 +1,15 @@
+#ifndef ENDIAN_H
+#define ENDIAN_H
+
+#if RETRO_USING_SDL
+#define RETRO_LE16(x) SDL_SwapLE16(x)
+#define RETRO_LE32(x) SDL_SwapLE32(x)
+#define RETRO_LE64(x) SDL_SwapLE64(x)
+#else
+//ummm
+#define RETRO_LE16(x) (x)
+#define RETRO_LE32(x) (x)
+#define RETRO_LE64(x) (x)
+#endif
+
+#endif //ENDIAN_H

--- a/Sonic12Decomp/Reader.cpp
+++ b/Sonic12Decomp/Reader.cpp
@@ -42,8 +42,9 @@ bool CheckRSDKFile(const char *filePath)
         Engine.usingDataFile = true;
         StrCopy(rsdkName, filePath);
 
-        rsdkContainer.fileCount = 0;
-        fRead(&rsdkContainer.fileCount, 2, 1, cFileHandle);
+        ushort fileCount = 0;
+        fRead(&fileCount, 2, 1, cFileHandle);
+        rsdkContainer.fileCount = RETRO_LE16(fileCount);
         for (int f = 0; f < rsdkContainer.fileCount; ++f) {
             for (int y = 0; y < 16; y += 4) {
                 fRead(&rsdkContainer.files[f].hash[y + 3], 1, 1, cFileHandle);
@@ -52,8 +53,11 @@ bool CheckRSDKFile(const char *filePath)
                 fRead(&rsdkContainer.files[f].hash[y + 0], 1, 1, cFileHandle);
             }
 
-            fRead(&rsdkContainer.files[f].offset, 4, 1, cFileHandle);
-            fRead(&rsdkContainer.files[f].filesize, 4, 1, cFileHandle);
+            int offset, filesize;
+            fRead(&offset, 4, 1, cFileHandle);
+            fRead(&filesize, 4, 1, cFileHandle);
+            rsdkContainer.files[f].offset = RETRO_LE32(offset);
+            rsdkContainer.files[f].filesize = RETRO_LE32(filesize);
 
             rsdkContainer.files[f].encrypted = (rsdkContainer.files[f].filesize & 0x80000000);
             rsdkContainer.files[f].filesize &= 0x7FFFFFFF;
@@ -134,7 +138,7 @@ bool LoadFile(const char *filePath, FileInfo *fileInfo)
                 memcpy(fileInfo->encryptionStringA, encryptionStringA, 0x10 * sizeof(byte));
                 memcpy(fileInfo->encryptionStringB, encryptionStringB, 0x10 * sizeof(byte));
             }
-            
+
             fileInfo->readPos           = readPos;
             fileInfo->fileSize          = fileSize;
             fileInfo->vfileSize         = vFileSize;

--- a/Sonic12Decomp/RetroEngine.cpp
+++ b/Sonic12Decomp/RetroEngine.cpp
@@ -204,11 +204,34 @@ bool processEvents()
     return true;
 }
 
+#if __WIIU__
+#include <whb/log.h>
+#include <whb/log_udp.h>
+#include <whb/log_cafe.h>
+#include <unistd.h>
+#include <sys/iosupport.h>
+
+static ssize_t wiiu_log_write(struct _reent* r, void* fd, const char* ptr, size_t len) {
+    WHBLogPrintf("%*.*s", len, len, ptr);
+    return len;
+}
+static const devoptab_t dotab_stdout = {
+    .name = "stdout_whb",
+    .write_r = wiiu_log_write,
+};
+#endif
+
 #if RETRO_USE_NETWORKING && RSDK_DEBUG
 #include <string>
 #endif
 void RetroEngine::Init()
 {
+#if __WIIU__
+    WHBLogUdpInit();
+    WHBLogCafeInit();
+    devoptab_list[STD_OUT] = &dotab_stdout;
+    devoptab_list[STD_ERR] = &dotab_stdout;
+#endif
     CalculateTrigAngles();
     GenerateBlendLookupTable();
 

--- a/Sonic12Decomp/RetroEngine.cpp
+++ b/Sonic12Decomp/RetroEngine.cpp
@@ -298,7 +298,7 @@ void RetroEngine::Init()
         gameType = GAME_SONIC2;
     }
 
-    
+
     ReadSaveRAMData();
     if (saveRAM[0x100] != Engine.gameType) {
         saveRAM[0x100] = Engine.gameType;
@@ -390,8 +390,8 @@ void RetroEngine::Run()
 bool RetroEngine::LoadGameConfig(const char *filePath)
 {
     FileInfo info;
-    int fileBuffer  = 0;
-    int fileBuffer2 = 0;
+    byte fileBuffer  = 0;
+    byte fileBuffer2 = 0;
     char strBuffer[0x40];
 
     bool loaded = LoadFile(filePath, &info);
@@ -411,7 +411,7 @@ bool RetroEngine::LoadGameConfig(const char *filePath)
         }
 
         // Read Obect Names
-        int objectCount = 0;
+        byte objectCount = 0;
         FileRead(&objectCount, 1);
         for (int o = 0; o < objectCount; ++o) {
             FileRead(&fileBuffer, 1);
@@ -424,7 +424,7 @@ bool RetroEngine::LoadGameConfig(const char *filePath)
             FileRead(&strBuffer, fileBuffer);
         }
 
-        int varCount = 0;
+        byte varCount = 0;
         FileRead(&varCount, 1);
         globalVariablesCount = varCount;
         for (int v = 0; v < varCount; ++v) {
@@ -445,7 +445,7 @@ bool RetroEngine::LoadGameConfig(const char *filePath)
         }
 
         // Read SFX
-        int globalSFXCount = 0;
+        byte globalSFXCount = 0;
         FileRead(&globalSFXCount, 1);
         for (int s = 0; s < globalSFXCount; ++s) { // SFX Names
             FileRead(&fileBuffer, 1);
@@ -459,7 +459,7 @@ bool RetroEngine::LoadGameConfig(const char *filePath)
         }
 
         // Read Player Names
-        int playerCount = 0;
+        byte playerCount = 0;
         FileRead(&playerCount, 1);
         for (int p = 0; p < playerCount; ++p) {
             FileRead(&fileBuffer, 1);
@@ -474,7 +474,9 @@ bool RetroEngine::LoadGameConfig(const char *filePath)
             else if (c == 3)
                 cat = 2;
             stageListCount[cat] = 0;
-            FileRead(&stageListCount[cat], 1);
+            byte count = 0;
+            FileRead(&count, 1);
+            stageListCount[cat] = count;
             for (int s = 0; s < stageListCount[cat]; ++s) {
 
                 // Read Stage Folder
@@ -501,7 +503,7 @@ bool RetroEngine::LoadGameConfig(const char *filePath)
         CloseFile();
     }
 
-    
+
     //These need to be set every time its reloaded
     nativeFunctionCount = 0;
     AddNativeFunction("SetAchievement", SetAchievement);

--- a/Sonic12Decomp/RetroEngine.hpp
+++ b/Sonic12Decomp/RetroEngine.hpp
@@ -153,6 +153,7 @@ extern bool usingCWD;
 #include "Text.hpp"
 #include "Userdata.hpp"
 #include "Debug.hpp"
+#include "Endian.hpp"
 
 //Native Entities
 #include "PauseMenu.hpp"
@@ -178,7 +179,7 @@ public:
     int frameSkipSetting = 0;
     int frameSkipTimer   = 0;
 
-    
+
     // Ported from RSDKv5
     bool devMenu = false;
     int startList  = 0;

--- a/Sonic12Decomp/Script.cpp
+++ b/Sonic12Decomp/Script.cpp
@@ -1731,7 +1731,7 @@ bool ConvertStringToInteger(const char *text, int *value)
                 charVal += 10;
                 *value += charVal;
             }
-            
+
         }
         else {
             int strlen = strLength + 1;
@@ -2048,7 +2048,7 @@ void LoadBytecode(int stageListID, int scriptID)
 
     FileInfo info;
     if (LoadFile(scriptPath, &info)) {
-        int fileBuffer = 0;
+        byte fileBuffer = 0;
         int *scrData   = &scriptData[scriptCodePos];
         FileRead(&fileBuffer, 1);
         int scriptDataCount = fileBuffer;

--- a/Sonic12Decomp/Sprite.cpp
+++ b/Sonic12Decomp/Sprite.cpp
@@ -38,7 +38,7 @@ byte TraceGifPrefix(uint *prefix, int code, int clearCode);
 
 void InitGifDecoder()
 {
-    int val = 0;
+    byte val = 0;
     FileRead(&val, 1);
     gifDecoder.fileState      = LOADING_IMAGE;
     gifDecoder.position       = 0;
@@ -260,7 +260,7 @@ int LoadBMPFile(const char *filePath, byte sheetID)
         GFXSurface *surface = &gfxSurface[sheetID];
         StrCopy(surface->fileName, filePath);
 
-        int fileBuffer = 0;
+        byte fileBuffer = 0;
 
         SetFilePosition(18);
         FileRead(&fileBuffer, 1);
@@ -314,7 +314,8 @@ int LoadGIFFile(const char *filePath, byte sheetID)
         GFXSurface *surface = &gfxSurface[sheetID];
         StrCopy(surface->fileName, filePath);
 
-        int fileBuffer = 0;
+        byte fileBuffer = 0;
+        int fileBuffer2 = 0;
 
         SetFilePosition(6); // GIF89a
         FileRead(&fileBuffer, 1);
@@ -340,10 +341,10 @@ int LoadGIFFile(const char *filePath, byte sheetID)
         FileRead(&fileBuffer, 1);
         while (fileBuffer != ',') FileRead(&fileBuffer, 1); // gif image start identifier
 
-        FileRead(&fileBuffer, 2);
-        FileRead(&fileBuffer, 2);
-        FileRead(&fileBuffer, 2);
-        FileRead(&fileBuffer, 2);
+        FileRead(&fileBuffer2, 2);
+        FileRead(&fileBuffer2, 2);
+        FileRead(&fileBuffer2, 2);
+        FileRead(&fileBuffer2, 2);
         FileRead(&fileBuffer, 1);
         bool interlaced = (fileBuffer & 0x40) >> 6;
         if (fileBuffer >> 7 == 1) {

--- a/Sonic12Decomp/String.cpp
+++ b/Sonic12Decomp/String.cpp
@@ -162,7 +162,7 @@ unsigned *md5(const char *msg, int mlen)
         {
             //            unsigned char t;
             WBunion u;
-            u.w = 8 * mlen;
+            u.w = RETRO_LE32(8 * mlen);
             //            t = u.b[0]; u.b[0] = u.b[3]; u.b[3] = t;
             //            t = u.b[1]; u.b[1] = u.b[2]; u.b[2] = t;
             q -= 8;
@@ -180,7 +180,7 @@ unsigned *md5(const char *msg, int mlen)
             o    = O[p];
             for (q = 0; q < 16; q++) {
                 g = (m * q + o) % 16;
-                f = abcd[1] + rol(abcd[0] + fctn(abcd) + k[q + 16 * p] + mm.w[g], rotn[q % 4]);
+                f = abcd[1] + rol(abcd[0] + fctn(abcd) + k[q + 16 * p] + RETRO_LE32(mm.w[g]), rotn[q % 4]);
 
                 abcd[0] = abcd[3];
                 abcd[3] = abcd[2];
@@ -196,7 +196,7 @@ unsigned *md5(const char *msg, int mlen)
         free(msg2);
 
     return h;
-}    
+}
 
 int FindStringToken(const char *string, const char *token, char stopID)
 {
@@ -264,7 +264,7 @@ void GenerateMD5FromString(const char *string, int len, byte *buffer)
     WBunion u;
 
     for (int i = 0; i < 4; ++i) {
-        u.w = d[i];
+        u.w = RETRO_LE32(d[i]);
         for (int c = 0; c < 4; ++c) buffer[(i << 2) + c] = u.b[c];
     }
 }
@@ -524,7 +524,7 @@ void ReadCreditsList(const char *filePath)
                 strCreditsList[creditsListSize] = stringStorage[stringStorePos];
                 StrCopy(dest, "NULL");
                 ReadCreditsLine(dest);
-                
+
                 if (dest[0] != '[' || dest[2] != ']') {
                     advance += 24.0;
                 }

--- a/Sonic12Decomp/Text.cpp
+++ b/Sonic12Decomp/Text.cpp
@@ -120,9 +120,9 @@ void LoadConfigListText(TextMenu *menu, int listNo)
 {
     FileInfo info;
     char strBuf[0x100];
-    int fileBuffer = 0;
-    int count      = 0;
-    int strLen     = 0;
+    byte fileBuffer = 0;
+    byte count      = 0;
+    byte strLen     = 0;
     if (LoadFile("Data/Game/GameConfig.bin", &info)) {
         // Name
         FileRead(&strLen, 1);
@@ -196,7 +196,7 @@ void LoadConfigListText(TextMenu *menu, int listNo)
 
         // Categories
         for (int c = 1; c <= 4; ++c) {
-            int stageCnt = 0;
+            byte stageCnt = 0;
             FileRead(&stageCnt, 1);
             for (int s = 0; s < stageCnt; ++s) {
                 //Stage Folder


### PR DESCRIPTION
Hiya!

I found out about this rad project today and spent the afternoon sifting through filesystem calls and endian issues, as well as my first Makefile for a while (I'm usually the cmake type). It was a lot of fun!

Here's what I've got:

- Fixes for the Makefile setup on Wii U. The toolchain is very similar to the switch/libnx stuff, in that you have to link against a specific library and do a post-build step to actually make the binary. I think sdl's pkg-config was pulling in the library, but since the SDL2 port depends on wut (the wiiu's libnx) it can only be used in .rpx-format homebrew. I updated the makefile to pull in some snippets from a local wut install, which in turn pulls in the correct devkitPPC variables and linker scripts and whatever, as well as that last step to convert elf to rpx.
  - The part of this that probably matters to you is that I had to add a new `SYSLIBS` variable *to the main Makefile* to get the linking order correct.
- A little bit of logging, since the SD card access is a touch slow on wiiu it's nice to see the messages fly by while waiting for the assets to load.
- Endian fixes throughout the file-parsing parts of the codebase. The new `RETRO_LE` macros should compile exactly the same on little-endian platforms without any impact. The changing of ints to bytes (needed for all the size-1 FileRead calls) would certainly be *different* - not sure if better or worse - but at least the code is more semantically correct.
  - These changes are kind of intrusive. I know you (amazing switch ports person) probably don't mind but I'm noting that here in case upstream sees it, since decompilation projects usually have to pick between 1:1 reversing and adding new things.

Note that if you end up building it (tested on devkitPPC r38, SDL 2.0.9 and some random wut git, but it should be fine on the release version) the A and B buttons are swapped by default, you'll wanna turn on fullscreen in the config, and I didn't check whether creating new files actually works on-console (other wiiu ports have had issues with that) - I just copied over the .bin stuff and a config from my emulation-based testing.

![Image of Sonic 2 '13 running on a Wii U gamepad](https://i.imgur.com/O9eYOX1.jpg)

(also, sorry about all the random whitespace changes, my editor just Does That)